### PR TITLE
Update soliant_fms_zbx_export_templates.xml

### DIFF
--- a/zabbix_templates/soliant_fms_zbx_export_templates.xml
+++ b/zabbix_templates/soliant_fms_zbx_export_templates.xml
@@ -6317,7 +6317,7 @@ else
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>system.run[&quot;ps -u fmserver -o state,comm&quot;,wait]</key>
+                    <key>system.run[&quot;ps -u fmserver,fmsase -o state,comm&quot;,wait]</key>
                     <delay>30s</delay>
                     <history>90d</history>
                     <trends>0</trends>


### PR DESCRIPTION
I just applied the FMC template to an FMC instance I created recently, and doing so triggered several spurious Problems in Zabbix:

- FMS process not running - Data API - macOS / FMC
- FMS process not running - Progressive Backup - macOS / FMC
- FMS process not running - Script Engine - macOS / FMC
- FMS process not running - WPE - macOS / FMC

In my stock FMC deployment, several of those processes (fmscwpc, fmsased, and fmwipd) seem to be running under the fmsase user instead of the fmserver user. The patch below -- including the fmsase user as a candidate for the the ps command in the "All FMS Processes" item -- caused the relevant processes to be reported correctly as running on the server.

It's unclear to me whether Progressive Backups / the fmsib process are still a feature on FMC, but if not, it may be worth removing that Trigger from the FMC template too. Since I didn't know, I didn't propose anything to that effect here.